### PR TITLE
Fix for the problems identified in issue1

### DIFF
--- a/check_aggregate_perfdata
+++ b/check_aggregate_perfdata
@@ -96,7 +96,7 @@ close($fh);
 if (scalar @servicestatus >= 1) {
   my $aggregate;
   foreach my $status(@servicestatus) {
-    if($$status{'performance_data'} =~ qr/^['"]?$perf_label['"]?=(\d+(?:\.\d+)?).*$/) {
+    if($$status{'performance_data'} =~ qr/['"]?$perf_label['"]?=(\d+(?:\.\d+)?).*/) {
       $aggregate += $1;
     }
   }

--- a/check_aggregate_perfdata
+++ b/check_aggregate_perfdata
@@ -95,11 +95,18 @@ close($fh);
 # If we found performance data, process it
 if (scalar @servicestatus >= 1) {
   my $aggregate;
+  my $match=0;
   foreach my $status(@servicestatus) {
     if($$status{'performance_data'} =~ qr/['"]?$perf_label['"]?=(\d+(?:\.\d+)?).*/) {
       $aggregate += $1;
+      $match++;
     }
   }
+  # Warn if we didn't find any matching perfdata
+  if ($match == 0) {
+    &quit('UNKNOWN',"Unable to find matching perfdata for that host/service/label");
+  }
+
   # Are we working on sum or average?
   my $rv = defined($average) ? $aggregate / scalar(@servicestatus) : $aggregate;
   my $av_txt = defined($average) ? "average" : "total";


### PR DESCRIPTION
- Removes the anchoring from the regex that matches perfdata so we can match elsewhere in the performance_data line
- Adds additional error checking to see if you're trying to aggregate a perfdata label which doesn't exist
